### PR TITLE
Refactor: 책 인식 API 호출 시 응답 성공 상태 비동기로 가져오기 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@tanstack/react-query": "^5.18.1",
         "@tanstack/react-query-devtools": "^5.18.1",
+        "axios": "^1.6.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "embla-carousel-react": "^8.0.0-rc23",
@@ -1445,6 +1446,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -1501,6 +1507,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1740,6 +1756,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1849,6 +1876,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2605,6 +2640,25 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2627,6 +2681,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3579,6 +3646,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4179,6 +4265,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@tanstack/react-query": "^5.18.1",
     "@tanstack/react-query-devtools": "^5.18.1",
+    "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "embla-carousel-react": "^8.0.0-rc23",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import backgroundImg from "../../public/images/bg_image.png";
 import FooterNav from "@/components/FooterNav";
 import ReactQueryProviders from "@/utils/ReactQueryProvider";
 import { Toaster } from "@/components/ui/toaster";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 // const inter = Inter({ subsets: ["latin"] });
 
@@ -30,7 +31,6 @@ export default function RootLayout({
       <body>
         <div className="flex items-center justify-center">
           <Image
-            // className="object-cover"
             src={backgroundImg}
             alt="Background"
             layout="fill"
@@ -39,17 +39,14 @@ export default function RootLayout({
             priority
             style={{ zIndex: -1 }}
           />
-          <div
-            className="flex items-center justify-center w-full h-full bg-black bg-opacity-60"
-            style={{ zIndex: 1 }}
-          >
-            <main className="flex flex-col h-screen w-[600px]">
+          <div className="flex items-center justify-center w-full h-full bg-black bg-opacity-60">
+            <main className="flex flex-col h-screen w-[450px]">
               <Header />
-              {/* <div className="border"></div> */}
-              <div className="relative h-full w-full bg-[#ffffff] overflow-y-auto flex justify-center">
-                {children}
-              </div>
-              {/* TODO: main이랑 footer랑 분리 */}
+              <ReactQueryProviders>
+                <div className="relative h-full w-full bg-[#ffffff] overflow-y-auto flex justify-center">
+                  {children}
+                </div>
+              </ReactQueryProviders>
               <div className="border"></div>
               <FooterNav />
             </main>

--- a/src/app/question/components/QuestionForm.tsx
+++ b/src/app/question/components/QuestionForm.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Book from "@/components/Book";
+import { Book as IBook } from "@/types/type";
+import { useQuery } from "@tanstack/react-query";
+import { getBooks } from "../lib/getBooks";
+
+export default function QuestionForm() {
+  const { data, isPending } = useQuery<IBook[]>({
+    queryKey: ["books"],
+    queryFn: getBooks,
+  });
+
+  if (isPending) {
+    return <p>Loading...</p>;
+  }
+
+  return data?.map((book) => <Book key={book.bookId} item={book} />);
+}

--- a/src/app/question/lib/getBooks.ts
+++ b/src/app/question/lib/getBooks.ts
@@ -1,0 +1,14 @@
+export async function getBooks() {
+  const response = await fetch("http://localhost:3000/book", {
+    next: {
+      tags: ["books"],
+    },
+    cache: "no-store",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error("서버에서 요청을 처리할 수 없습니다.");
+  }
+  return response.json();
+}

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -1,8 +1,19 @@
 "use client";
-
-import useBookStore from "@/store/bookStore";
+import { QueryClient } from "@tanstack/react-query";
+import QuestionForm from "./components/QuestionForm";
+import { getBooks } from "./lib/getBooks";
+import useSuccessStore from "@/store/successStore";
+import { Divide } from "lucide-react";
 
 export default function Question() {
-  const books = useBookStore((set) => set.books);
-  return <div>야호</div>;
+  // const queryClient = new QueryClient();
+  // await queryClient.prefetchQuery({ queryKey: ["books"], queryFn: getBooks });
+  const isSuccess = useSuccessStore((state) => state.isSuccess);
+
+  return (
+    <div className="flex flex-col w-4/5 mt-10 mb-10">
+      {isSuccess ? <div>성공</div> : <div>실패</div>}
+      {/* <QuestionForm /> */}
+    </div>
+  );
 }

--- a/src/components/Book.tsx
+++ b/src/components/Book.tsx
@@ -1,0 +1,33 @@
+import { Book as IBook } from "@/types/type";
+import Image from "next/image";
+
+type Props = {
+  item: IBook;
+};
+
+export default function Book({ item }: Props) {
+  return (
+    <div className="w-2/3 p-4 space-y-4 overflow-y-auto border rounded-lg shadow-2xl h-3/4 mb-30 border-slate-300">
+      <div className="flex items-center mb-2">
+        <div className="flex-shrink-0">
+          <Image
+            alt="Book cover"
+            className="object-cover w-10 h-15"
+            height="60"
+            src={item.titleUrl || "/images/logo.png"}
+            style={{
+              aspectRatio: "40/60",
+              objectFit: "cover",
+            }}
+            width="40"
+          />
+        </div>
+        <div className="flex flex-col justify-center ml-3">
+          <div className="text-sm font-light">{item.title}</div>
+          <div className="text-xs text-gray-500">{item.publisher}</div>
+          <div className="text-xs text-gray-500">{item.author}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/store/successStore.ts
+++ b/src/store/successStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface SuccessStoreState {
+  isSuccess: boolean;
+  setIsSuccess: (isSuccess: boolean) => void;
+}
+// Zustand 스토어 생성
+const useSuccessStore = create<SuccessStoreState>((set) => ({
+  isSuccess: false,
+  setIsSuccess: (isSuccess) => set(() => ({ isSuccess })),
+}));
+
+export default useSuccessStore;

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,0 +1,17 @@
+export interface Book {
+  bookId: number;
+  title: string;
+  publisher: string;
+  author: string;
+  titleUrl: string;
+  eaAddCode: string;
+  eaIsbn: string;
+  setIsbn: string;
+  setAddCode: string;
+  prePrice: string;
+  inputDate: string;
+  createdAt: string;
+  updatedAt: string;
+  status?: string | null;
+  rank?: number;
+}

--- a/src/utils/ReactQueryProvider.tsx
+++ b/src/utils/ReactQueryProvider.tsx
@@ -12,7 +12,7 @@ export default function ReactQueryProviders({
         queries: {
           refetchOnWindowFocus: false, // 윈도우가 다시 포커스되었을때 데이터를 refetch
           refetchOnMount: false, // 데이터가 stale 상태이면 컴포넌트가 마운트될 때 refetch
-          retry: 1, // API 요청 실패시 재시도 하는 옵션 (설정값 만큼 재시도)
+          retry: false, // API 요청 실패시 재시도 하는 옵션 (설정값 만큼 재시도)
         },
       },
     })


### PR DESCRIPTION
### 📟 연결된 이슈
#12 

### 👷 작업한 내용
- 사용한 툴
  - @tanstack/react-query, zustand
- react-query는 서버의 데이터를 Fetching 할 때 사용하는 툴로, 서버로부터 가져온 데이터의 상태를 관리할 수 있다. 서버에 POST 요청(react-query에서 Mutation으로 사용됨)을 날리면 지정한 함수가 실행되도록 할 수 있는데 해당 함수에서 우선 다음 라우트(/survey)로 이동하게 한 다음 fetch 함수를 실행하고 해당 응답을 리턴한다. useMutation에는 onSuccess라고 요청이 성공 시에 특정 로직을 실행할 수 있는 콜백을 지원하는데 해당 함수에서 zustand로 관리하는 isSuccess 상태를 false에서 true로 변경되도록 하였다.
- /survey에서는 zustand의 isSuccess를 꺼내와서 해당 값을 버튼의 상태에 활용하면 된다.

### TODO
- [ ] /question으로 라우팅 되도록 한 것을 /survey로 바꾸기 (/survey가 만들어지는대로)
- [ ] 백엔드 서버에서 더미 데이터를 쓰는 것이 아니라 AI 서버에 요청을 보내도록 변경되면 setTimeout 제거하기(우선은 오래걸리는 요청을 구현하기 위해서 setTimeout으로 10초가 걸리도록 설정했음)

### 📸 스크린샷
